### PR TITLE
For the arm64 M1 in README, stress Monterey (macOS 12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ If you use `conda` on macOS and after `import stardist` see errors similar to `S
 
 ##### Apple Silicon
 
-As of StarDist 0.8.2, we provide `arm64` wheels that should work with macOS on Apple M1. 
-We recommend setting up an `arm64` `conda` environment with GPU-accelerated TensorFlow following [Apple's instructions](https://developer.apple.com/metal/tensorflow-plugin/) (ensure you are using macOS 12 Monterrey or newer) using [conda-forge miniforge3 or mambaforge](https://github.com/conda-forge/miniforge). Then install `stardist` using `pip`.
+As of StarDist 0.8.2, we provide `arm64` wheels that should work with [macOS on Apple Silicon](https://support.apple.com/en-us/HT211814) (M1 chip or newer). 
+We recommend setting up an `arm64` `conda` environment with GPU-accelerated TensorFlow following [Apple's instructions](https://developer.apple.com/metal/tensorflow-plugin/) (ensure you are using macOS 12 Monterey or newer) using [conda-forge miniforge3 or mambaforge](https://github.com/conda-forge/miniforge). Then install `stardist` using `pip`.
 ```
 conda create -y -n stardist-env python=3.9   
 conda activate stardist-env

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ If you use `conda` on macOS and after `import stardist` see errors similar to `S
 ##### Apple Silicon
 
 As of StarDist 0.8.2, we provide `arm64` wheels that should work with macOS on Apple M1. 
-We recommend setting up an `arm64` `conda` environment with GPU-accelerated TensorFlow following [Apple's instructions](https://developer.apple.com/metal/tensorflow-plugin/) using [conda-forge miniforge3 or mambaforge](https://github.com/conda-forge/miniforge). Then install `stardist` using `pip`.
+We recommend setting up an `arm64` `conda` environment with GPU-accelerated TensorFlow following [Apple's instructions](https://developer.apple.com/metal/tensorflow-plugin/) (ensure you are using macOS 12 Monterrey or newer) using [conda-forge miniforge3 or mambaforge](https://github.com/conda-forge/miniforge). Then install `stardist` using `pip`.
 ```
 conda create -y -n stardist-env python=3.9   
 conda activate stardist-env


### PR DESCRIPTION

As noted in https://github.com/stardist/stardist/issues/174 on arm64 macOS, the version needs to be 12+ (Monterrey+) to ensure full performance. This is actually what Apple recommends in the tensorflow-metal docs (https://developer.apple.com/metal/tensorflow-plugin/).

So this PR just edits the README Apple M1 section to clearly state that.
