### PR TITLE
Add new hashes using SHA-256 to avoid errors on systems in FIPS mode

### DIFF
--- a/stardist/models/__init__.py
+++ b/stardist/models/__init__.py
@@ -16,11 +16,11 @@ del backend_channels_last, K
 from csbdeep.models import register_model, register_aliases, clear_models_and_aliases
 # register pre-trained models and aliases (TODO: replace with updatable solution)
 clear_models_and_aliases(StarDist2D, StarDist3D)
-register_model(StarDist2D,   '2D_versatile_fluo', 'https://github.com/stardist/stardist-models/releases/download/v0.1/python_2D_versatile_fluo.zip', '8db40dacb5a1311b8d2c447ad934fb8a')
-register_model(StarDist2D,   '2D_versatile_he',   'https://github.com/stardist/stardist-models/releases/download/v0.1/python_2D_versatile_he.zip', 'bf34cb3c0e5b3435971e18d66778a4ec')
-register_model(StarDist2D,   '2D_paper_dsb2018',  'https://github.com/stardist/stardist-models/releases/download/v0.1/python_2D_paper_dsb2018.zip', '6287bf283f85c058ec3e7094b41039b5')
-register_model(StarDist2D,   '2D_demo',           'https://github.com/stardist/stardist-models/releases/download/v0.1/python_2D_demo.zip', '31f70402f58c50dd231ec31b4375ea2c')
-register_model(StarDist3D,   '3D_demo',           'https://github.com/stardist/stardist-models/releases/download/v0.1/python_3D_demo.zip', 'f481c16c1ee9f28a8dcfa1e7aae3dc83')
+register_model(StarDist2D,   '2D_versatile_fluo', 'https://github.com/stardist/stardist-models/releases/download/v0.1/python_2D_versatile_fluo.zip', '4ad678d0758eed6e55625f1b5ae30771e59adb79f1239e09b9772eac8846c3dd')
+register_model(StarDist2D,   '2D_versatile_he',   'https://github.com/stardist/stardist-models/releases/download/v0.1/python_2D_versatile_he.zip', 'f1696ef0631bd7e1c0e5c0d3017e2b4c6a95e284c6aab9c22fc2f08317817b28')
+register_model(StarDist2D,   '2D_paper_dsb2018',  'https://github.com/stardist/stardist-models/releases/download/v0.1/python_2D_paper_dsb2018.zip', '4c11cf68512341d9e8ce3d1278c64ceb8ac400582739f85fcab079a2e82840d2')
+register_model(StarDist2D,   '2D_demo',           'https://github.com/stardist/stardist-models/releases/download/v0.1/python_2D_demo.zip', 'a1efaebd7103db6236655bf158b6e21cf5b38d58ec77a509802244a89a260fa4')
+register_model(StarDist3D,   '3D_demo',           'https://github.com/stardist/stardist-models/releases/download/v0.1/python_3D_demo.zip', 'ea05831eb5acc8a2fd31eaa23f4460a196a9af53b14f40affb9d80885f699f90')
 
 register_aliases(StarDist2D, '2D_paper_dsb2018',  'DSB 2018 (from StarDist 2D paper)')
 register_aliases(StarDist2D, '2D_versatile_fluo', 'Versatile (fluorescent nuclei)')


### PR DESCRIPTION
This simply changes the hashes used to validate downloaded files from MD5 to SHA-256. This prevents issues with downloading models on systems with FIPS mode enabled, but does not affect the functionality otherwise. See #289 for details.

Resolves #289