### PR TITLE
Add NumPy 2.x compatibility flags to build process

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,13 +106,13 @@ setup(
         Extension(
             'stardist.lib.stardist2d',
             sources = ['stardist/lib/stardist2d.cpp', 'stardist/lib/utils.cpp'] + clipper_src,
-            extra_compile_args = ['-std=c++11'],
+            extra_compile_args = ['-std=c++11', '-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION'],  # ADDED FLAG HERE
             include_dirs = get_numpy_include_dirs() + [clipper_root, nanoflann_root],
         ),
         Extension(
             'stardist.lib.stardist3d',
             sources = ['stardist/lib/stardist3d.cpp', 'stardist/lib/stardist3d_impl.cpp', 'stardist/lib/utils.cpp'] + qhull_src,
-            extra_compile_args = ['-std=c++11'],
+            extra_compile_args = ['-std=c++11', '-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION'],  # ADDED FLAG HERE
             include_dirs = get_numpy_include_dirs() + [qhull_root, nanoflann_root],
         ),
     ],


### PR DESCRIPTION
# Add NumPy 2.x compatibility flags to build process

This PR adds NumPy 2.x compatibility flags to the build process by adding the `-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION` flag to both Extension definitions in setup.py.

## Problem
Modules compiled using NumPy 1.x cannot be run with NumPy 2.x, resulting in this error:
"A module that was compiled using NumPy 1.x cannot be run in NumPy 2.x as it may crash."

## Solution
Added compatibility flags to the C++ extensions to use the newer NumPy C API, which resolves the error.

## Testing
Tested successfully with:
- Python 3.11.3
- NumPy 2.1.3
- Linux environment

This allows StarDist to work with newer NumPy versions without requiring users to downgrade NumPy, which would break compatibility with other libraries that require NumPy 2.x.