### PR TITLE
Add wandb support (mirrors TB logs)

### DIFF
--- a/stardist/models/base.py
+++ b/stardist/models/base.py
@@ -229,6 +229,7 @@ class StarDistBase(BaseModel):
 
     def __init__(self, config, name=None, basedir='.'):
         super().__init__(config=config, name=name, basedir=basedir)
+        self._wandb_run = None
         threshs = dict(prob=None, nms=None)
         if basedir is not None:
             try:
@@ -358,6 +359,8 @@ class StarDistBase(BaseModel):
                 else:
                     self.callbacks.append(TensorBoard(log_dir=str(self.logdir/'logs'), write_graph=False, profile_batch=0))
 
+        self._wandb_prepare()
+
         if self.config.train_reduce_lr is not None:
             rlrop_params = self.config.train_reduce_lr
             if 'verbose' not in rlrop_params:
@@ -366,6 +369,48 @@ class StarDistBase(BaseModel):
             self.callbacks.insert(0,ReduceLROnPlateau(**rlrop_params))
 
         self._model_prepared = True
+
+
+    def _wandb_prepare(self):
+        """Start optional W&B run that mirrors existing TensorBoard logs."""
+        project = getattr(self.config, 'train_wandb_project', None)
+        if not project or self._wandb_run is not None:
+            return
+
+        if self.basedir is None:
+            raise RuntimeError(
+                "W&B mirroring requires a model 'basedir' so TensorBoard logs can be written."
+            )
+        if not self.config.train_tensorboard:
+            raise RuntimeError(
+                "W&B mirroring requires 'train_tensorboard=True'."
+            )
+        try:
+            import wandb
+        except ImportError as e:
+            raise RuntimeError(
+                "W&B support requested via 'train_wandb_project', but 'wandb' is not installed.\n"
+                "Install it with: pip install wandb"
+            ) from e
+        logdir = str(self.logdir)
+        wandb.tensorboard.patch(root_logdir=str(self.logdir / 'logs'))
+        self._wandb_run = wandb.init(
+            project=str(project),
+            name=self.logdir.name,
+            dir=logdir,
+            config=vars(self.config),
+        )
+
+
+    def _wandb_finish(self):
+        """Finish active W&B run started by ``_wandb_prepare``."""
+        if self._wandb_run is None:
+            return
+        try:
+            import wandb
+            wandb.finish()
+        finally:
+            self._wandb_run = None
 
 
     def _predict_setup(self, img, axes, normalizer, n_tiles, show_tile_progress, predict_kwargs):

--- a/stardist/models/model2d.py
+++ b/stardist/models/model2d.py
@@ -187,6 +187,8 @@ class Config2D(BaseConfig):
         Number of patches to be extracted from validation images (``None`` = one patch per image).
     train_tensorboard : bool
         Enable TensorBoard for monitoring training progress.
+    train_wandb_project : str or None
+        Set to a Weights & Biases project name to enable mirroring of TensorBoard logs.
     train_reduce_lr : dict
         Parameter :class:`dict` of ReduceLROnPlateau_ callback; set to ``None`` to disable.
     use_gpu : bool
@@ -248,6 +250,7 @@ class Config2D(BaseConfig):
         self.train_batch_size          = 4
         self.train_n_val_patches       = None
         self.train_tensorboard         = True
+        self.train_wandb_project       = None
         # the parameter 'min_delta' was called 'epsilon' for keras<=2.1.5
         # keras.__version__ was removed in tensorflow 2.13.0
         min_delta_key = 'epsilon' if Version(getattr(keras, '__version__', '9.9.9'))<=Version('2.1.5') else 'min_delta'
@@ -473,12 +476,15 @@ class StarDist2D(StarDistBase):
                                                            n_images=3, prob_out=False, output_slices=output_slices))
 
         fit = self.keras_model.fit_generator if (IS_TF_1 and not IS_KERAS_3_PLUS) else self.keras_model.fit
-        history = fit(iter(self.data_train), validation_data=data_val,
-                      epochs=epochs, steps_per_epoch=steps_per_epoch,
-                      **fit_kwargs,
-                      callbacks=self.callbacks, verbose=1,
-                      # set validation batchsize to training batchsize (only works for tf >= 2.2)
-                      **(dict(validation_batch_size = self.config.train_batch_size) if _tf_version_at_least("2.2.0") else {}))
+        try:
+            history = fit(iter(self.data_train), validation_data=data_val,
+                          epochs=epochs, steps_per_epoch=steps_per_epoch,
+                          **fit_kwargs,
+                          callbacks=self.callbacks, verbose=1,
+                          # set validation batchsize to training batchsize (only works for tf >= 2.2)
+                          **(dict(validation_batch_size = self.config.train_batch_size) if _tf_version_at_least("2.2.0") else {}))
+        finally:
+            self._wandb_finish()
         self._training_finished()
 
         return history

--- a/stardist/models/model3d.py
+++ b/stardist/models/model3d.py
@@ -201,6 +201,8 @@ class Config3D(BaseConfig):
         Batch size for training.
     train_tensorboard : bool
         Enable TensorBoard for monitoring training progress.
+    train_wandb_project : str or None
+        Set to a Weights & Biases project name to enable mirroring of TensorBoard logs.
     train_n_val_patches : int
         Number of patches to be extracted from validation images (``None`` = one patch per image).
     train_reduce_lr : dict
@@ -290,6 +292,7 @@ class Config3D(BaseConfig):
         self.train_batch_size          = 1
         self.train_n_val_patches       = None
         self.train_tensorboard         = True
+        self.train_wandb_project       = None
         # the parameter 'min_delta' was called 'epsilon' for keras<=2.1.5
         # keras.__version__ was removed in tensorflow 2.13.0
         min_delta_key = 'epsilon' if Version(getattr(keras, '__version__', '9.9.9'))<=Version('2.1.5') else 'min_delta'
@@ -576,12 +579,15 @@ class StarDist3D(StarDistBase):
                                                            n_images=3, prob_out=False, input_slices=input_slices, output_slices=output_slices))
 
         fit = self.keras_model.fit_generator if (IS_TF_1 and not IS_KERAS_3_PLUS) else self.keras_model.fit
-        history = fit(iter(self.data_train), validation_data=data_val,
-                      epochs=epochs, steps_per_epoch=steps_per_epoch,
-                      **fit_kwargs,
-                      callbacks=self.callbacks, verbose=1,
-                      # set validation batchsize to training batchsize (only works in tf 2.x)
-                      **(dict(validation_batch_size = self.config.train_batch_size) if _tf_version_at_least("2.2.0") else {}))
+        try:
+            history = fit(iter(self.data_train), validation_data=data_val,
+                          epochs=epochs, steps_per_epoch=steps_per_epoch,
+                          **fit_kwargs,
+                          callbacks=self.callbacks, verbose=1,
+                          # set validation batchsize to training batchsize (only works in tf 2.x)
+                          **(dict(validation_batch_size = self.config.train_batch_size) if _tf_version_at_least("2.2.0") else {}))
+        finally:
+            self._wandb_finish()
         self._training_finished()
 
         return history


### PR DESCRIPTION
Adds W&B support for nicer training logging.

-  mirrors existing TensorBoard logging (losses + images).
- can be activated by setting `train_wandb_project` to a W&B project name in Config2D/Config3D
- Run name is auto-derived from the model folder name