### PR TITLE
setup.py: Adjust compiler flags for current macOS and detect correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools.command.build_ext import build_ext
 from numpy import get_include
 from os import path
 from glob import glob
+import platform
 
 
 def get_numpy_include_dirs():
@@ -14,9 +15,10 @@ class build_ext_openmp(build_ext):
     # https://www.openmp.org/resources/openmp-compilers-tools/
     # python setup.py build_ext --help-compiler
     openmp_compile_args = {
-        'msvc':  [['/openmp']],
-        'intel': [['-qopenmp']],
-        '*':     [['-fopenmp'], ['-Xpreprocessor','-fopenmp']],
+        'msvc':             [['/openmp']],
+        'intel':            [['-qopenmp']],
+        'clang-darwin':     [[], ['-Xpreprocessor','-lomp']],
+        '*':                [['-fopenmp'], ['-Xpreprocessor','-fopenmp']],
     }
     openmp_link_args = openmp_compile_args # ?
 
@@ -24,6 +26,8 @@ class build_ext_openmp(build_ext):
         compiler = self.compiler.compiler_type.lower()
         if compiler.startswith('intel'):
             compiler = 'intel'
+        if compiler.startswith('unix') and platform.system().lower().startswith('darwin'):
+            compiler = 'clang-darwin'
         if compiler not in self.openmp_compile_args:
             compiler = '*'
 


### PR DESCRIPTION
This PR adds a fix to setup.py to detect a current macOS environment correctly and set the compiler/linker flags accordingly. Note that this requires OpenMP (`libomp`) to be installed via homebrew.

Edit: This should fix the issues in https://github.com/stardist/stardist/issues/19 and https://github.com/stardist/stardist/issues/262, at least when using a current macOS dev environment (macOS 26.4, Xcode 26.4 with command line tools).